### PR TITLE
Restart can ASAP

### DIFF
--- a/can_hat_setup.bash
+++ b/can_hat_setup.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 sudo ip link set $1 down
-sudo ip link set $1 up type can bitrate $2 dbitrate $(($2*8)) restart-ms 1000 berr-reporting on fd on
+sudo ip link set $1 up type can bitrate $2 dbitrate $(($2*8)) restart-ms 100 berr-reporting on fd on
 sudo ip link set $1 name $1
 sudo ifconfig $1 txqueuelen 65536
 


### PR DESCRIPTION
バスオフからの自動回復を早く行うようにします。

Linuxドキュメントで例示されている100を使用します
https://docs.kernel.org/networking/can.html