### PR TITLE
Supports flagged patterns like CANHAT FD

### DIFF
--- a/can_monitor.sh
+++ b/can_monitor.sh
@@ -21,7 +21,8 @@ check_and_reset_can() {
     fi
 
     # Get CAN state
-    local can_state=$(ip -details link show "$interface" | grep -oP 'can state \K[^ ]+')
+    # Pattern matches both "can state ERROR-ACTIVE" and "can <FLAGS> state ERROR-ACTIVE"
+    local can_state=$(ip -details link show "$interface" | grep -oP 'can\s+(<[^>]+>\s+)?state\s+\K[^ ]+')
 
     if [[ -z "$can_state" ]]; then
         log_message "WARNING: Could not determine state for $interface"
@@ -40,7 +41,7 @@ check_and_reset_can() {
 
             # Wait a moment and check new state
             sleep 1
-            local new_state=$(ip -details link show "$interface" | grep -oP 'can state \K[^ ]+')
+            local new_state=$(ip -details link show "$interface" | grep -oP 'can\s+(<[^>]+>\s+)?state\s+\K[^ ]+')
             log_message "INFO: $interface new state is $new_state"
         else
             log_message "ERROR: Failed to reset $interface"


### PR DESCRIPTION
In the output of FD and plus, the FD case includes the flag <> (line 4).

case of CAN HAT Plus
```
$ ip -details link show can0
3: can0: <NOARP,UP,LOWER_UP,ECHO> mtu 16 qdisc pfifo_fast state UP mode DEFAULT group default qlen 65536
    link/can  promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 
    can state ERROR-ACTIVE restart-ms 1000 
	  bitrate 250000 sample-point 0.875
	  tq 250 prop-seg 6 phase-seg1 7 phase-seg2 2 sjw 1 brp 2
	  mcp251x: tseg1 3..16 tseg2 2..8 sjw 1..4 brp 1..64 brp_inc 1
	  clock 8000000 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus spi parentdev spi1.2
```

case of CANHAT FD
```
$ ip -details link show can0
3: can0: <NOARP,UP,LOWER_UP,ECHO> mtu 72 qdisc pfifo_fast state UP mode DEFAULT group default qlen 65536
    link/can  promiscuity 0  allmulti 0 minmtu 0 maxmtu 0 
    can <BERR-REPORTING,FD,TDC-AUTO> state ERROR-ACTIVE (berr-counter tx 0 rx 0) restart-ms 100 
	  bitrate 250000 sample-point 0.875
	  tq 25 prop-seg 69 phase-seg1 70 phase-seg2 20 sjw 10 brp 1
	  mcp251xfd: tseg1 2..256 tseg2 1..128 sjw 1..128 brp 1..256 brp_inc 1
	  dbitrate 2000000 dsample-point 0.750
	  dtq 25 dprop-seg 7 dphase-seg1 7 dphase-seg2 5 dsjw 2 dbrp 1
	  tdco 15
	  mcp251xfd: dtseg1 1..32 dtseg2 1..16 dsjw 1..16 dbrp 1..256 dbrp_inc 1
	  tdcv 0..63 tdco 0..63
	  clock 40000000 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 parentbus spi parentdev spi0.0
```